### PR TITLE
Add g:writegooder_disable_mappings to disable mappings

### DIFF
--- a/doc/writegooder.txt
+++ b/doc/writegooder.txt
@@ -56,8 +56,15 @@ Features:~
 ===============================================================================
 3. Mappings                                                *writegooder-mappings*
 
-The default mapping for toggling the highlighting on and off is <leader>wg.
+The default mapping for toggling the highlighting on and off is <leader>wg, but
+you can disable it by adding the following somewhere inside your .vimrc file:
+
+>
+    set g:writegooder_disable_mappings = 1
+<
+
 Use :nmap to change it to something else:
+
 >
     :nmap <leader>ww :WritegooderToggle<cr>
 <

--- a/plugin/writegooder.vim
+++ b/plugin/writegooder.vim
@@ -11,6 +11,9 @@ if exists('g:loaded_writegooder') || &cp
 endif
 
 let g:loaded_writegooder = 1
+if !exists("g:writegooder_disable_mappings")
+    let g:writegooder_disable_mappings = 0
+endif
 
 function! s:WritegooderToggle()
     call writegooder#toggle()
@@ -29,4 +32,6 @@ command! -bar WritegooderEnable       call s:WritegooderEnable()
 command! -bar WritegooderDisable      call s:WritegooderDisable()
 
 " Default mapping
-nmap <leader>wg :WritegooderToggle<cr>
+if !g:writegooder_disable_mappings
+    nmap <leader>wg :WritegooderToggle<cr>
+endif


### PR DESCRIPTION
This PR adds a new global variable, `g:writegooder_disable_mappings`, users can set to `1` to prevent the plugin from creating a new `<leader>wg` mapping.

If you don't use it, the plugin should behave as before